### PR TITLE
Release 0.1.2-rc.1 to next

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,3 +85,20 @@ jobs:
       - name: Publish to npm
         if: steps.registry.outputs.exists != 'true'
         run: npm publish --provenance --access public --tag "${{ steps.release.outputs.npm_tag }}"
+      - name: Verify the published dist-tag
+        shell: bash
+        run: |
+          package_name="$(node -p "require('./package.json').name")"
+          expected_version="${{ steps.release.outputs.version }}"
+          npm_tag="${{ steps.release.outputs.npm_tag }}"
+          for attempt in {1..12}; do
+            actual_version="$(npm view "${package_name}@${npm_tag}" version 2>/dev/null || true)"
+            if [[ "${actual_version}" == "${expected_version}" ]]; then
+              echo "${package_name}@${npm_tag} resolves to ${actual_version}"
+              exit 0
+            fi
+            echo "Attempt ${attempt}: expected ${expected_version}, observed ${actual_version:-<missing>}"
+            sleep 5
+          done
+          echo "${package_name}@${npm_tag} did not resolve to ${expected_version}" >&2
+          exit 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relay-dsh-plugin-codex",
-  "version": "0.1.1",
+  "version": "0.1.2-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relay-dsh-plugin-codex",
-      "version": "0.1.1",
+      "version": "0.1.2-rc.1",
       "dependencies": {
         "@openai/codex": "0.149.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relay-dsh-plugin-codex",
-  "version": "0.1.1",
+  "version": "0.1.2-rc.1",
   "description": "Codex conversation backend for DeepSeek Harness, powered by the Codex App Server with approvals and DSH tool support.",
   "license": "MIT",
   "type": "module",

--- a/test/release-metadata.test.mjs
+++ b/test/release-metadata.test.mjs
@@ -32,6 +32,8 @@ test("release workflow uses guarded tokenless npm publishing", async () => {
   assert.match(workflow, /git merge-base --is-ancestor/);
   assert.match(workflow, /b150a551b8d465e31e418e1b2eaf5e79bbb7d28e/);
   assert.match(workflow, /npm publish --provenance --access public --tag/);
+  assert.match(workflow, /Verify the published dist-tag/);
+  assert.match(workflow, /npm view \"\$\{package_name\}@\$\{npm_tag\}\" version/);
   assert.match(workflow, /os: \[ubuntu-latest, macos-latest, windows-latest\]/);
   assert.match(workflow, /publish:\s+needs: codex-runtime/);
   assert.ok(


### PR DESCRIPTION
Summary
- prepare relay-dsh-plugin-codex 0.1.2-rc.1
- keep prereleases mapped to the next dist-tag
- verify the published dist-tag by reading it back from npm

Validation
- release metadata tests passed
- PATH-independent Codex runtime tests passed: 23/23
- package dry-run contains the expected 0.1.2-rc.1 manifest
- full official-DSH verification runs in CI