### PR TITLE
Release 0.1.2 to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relay-dsh-plugin-codex",
-  "version": "0.1.2-rc.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relay-dsh-plugin-codex",
-      "version": "0.1.2-rc.1",
+      "version": "0.1.2",
       "dependencies": {
         "@openai/codex": "0.149.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relay-dsh-plugin-codex",
-  "version": "0.1.2-rc.1",
+  "version": "0.1.2",
   "description": "Codex conversation backend for DeepSeek Harness, powered by the Codex App Server with approvals and DSH tool support.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Summary
- promote the verified 0.1.2 release line from rc to stable
- publish the reliability closure to the npm latest dist-tag
- retain 0.1.2-rc.1 as the current next channel

Validation
- release metadata maps 0.1.2 to latest
- release metadata tests passed: 5/5
- PATH-independent Codex runtime tests passed: 23/23
- package dry-run contains the expected 0.1.2 manifest
- full official-DSH verification runs in CI