### PR TITLE
Add DSH plugin keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "relay-dsh-plugin-codex",
   "version": "0.1.3",
   "description": "Codex conversation backend for DeepSeek Harness, powered by the Codex App Server with approvals and DSH tool support.",
+  "keywords": ["dsh-plugin", "deepseek-harness", "dsh"],
   "license": "MIT",
   "type": "module",
   "main": "lib/host-plugin.js",


### PR DESCRIPTION
## Summary

- add npm discovery keywords to `package.json`
- keep the package version unchanged

## Validation

- `npm pkg get keywords --json`

Closes #21.

Note: this PR does not publish a new npm version.