### PR TITLE
chore: release Codex plugin 0.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/yangbobo2021/relay-dsh-plugin-codex?style=flat)](https://github.com/yangbobo2021/relay-dsh-plugin-codex/stargazers)
 [![MIT license](https://img.shields.io/github/license/yangbobo2021/relay-dsh-plugin-codex)](LICENSE)
 [![DSH compatibility](https://img.shields.io/badge/DSH-0.1.1--rc.2-2f7d68)](https://github.com/deepseek-ai/deepseek-harness)
-[![npm provenance](https://img.shields.io/badge/npm_provenance-verified-2f9e44)](https://www.npmjs.com/package/relay-dsh-plugin-codex/v/0.1.4)
+[![npm provenance](https://img.shields.io/badge/npm_provenance-verified-2f9e44)](https://www.npmjs.com/package/relay-dsh-plugin-codex/v/0.1.5)
 
 English | [中文](README.zh.md)
 
@@ -120,7 +120,7 @@ Use `@latest` to install the current stable release:
 npx @deepseek-ai/dsh@0.1.1-rc.2 plugin --profile web add relay-dsh-plugin-codex@latest
 ```
 
-At the time of writing, `latest` resolves to stable version `0.1.4`. The linked
+At the time of writing, `latest` resolves to stable version `0.1.5`. The linked
 npm page is the source of truth for the current version.
 
 #### npm prerelease (recommended during DSH preview)
@@ -148,7 +148,7 @@ npx @deepseek-ai/dsh@0.1.1-rc.2 plugin --profile web add github:yangbobo2021/rel
 full Commit SHA instead. For example:
 
 ```bash
-npx @deepseek-ai/dsh@0.1.1-rc.2 plugin --profile web add github:yangbobo2021/relay-dsh-plugin-codex#v0.1.4
+npx @deepseek-ai/dsh@0.1.1-rc.2 plugin --profile web add github:yangbobo2021/relay-dsh-plugin-codex#v0.1.5
 ```
 
 The official DSH CLI initializes the `web` Profile if it does not exist, asks

--- a/README.zh.md
+++ b/README.zh.md
@@ -6,7 +6,7 @@
 [![GitHub Stars](https://img.shields.io/github/stars/yangbobo2021/relay-dsh-plugin-codex?style=flat)](https://github.com/yangbobo2021/relay-dsh-plugin-codex/stargazers)
 [![MIT 许可证](https://img.shields.io/github/license/yangbobo2021/relay-dsh-plugin-codex)](LICENSE)
 [![DSH 兼容版本](https://img.shields.io/badge/DSH-0.1.1--rc.2-2f7d68)](https://github.com/deepseek-ai/deepseek-harness)
-[![npm 来源证明](https://img.shields.io/badge/npm_provenance-verified-2f9e44)](https://www.npmjs.com/package/relay-dsh-plugin-codex/v/0.1.4)
+[![npm 来源证明](https://img.shields.io/badge/npm_provenance-verified-2f9e44)](https://www.npmjs.com/package/relay-dsh-plugin-codex/v/0.1.5)
 
 [English](README.md) | 中文
 
@@ -114,7 +114,7 @@ codex login
 npx @deepseek-ai/dsh@0.1.1-rc.2 plugin --profile web add relay-dsh-plugin-codex@latest
 ```
 
-本文更新时，`latest` 指向稳定版 `0.1.4`。最新版本请以链接中的 npm 页面
+本文更新时，`latest` 指向稳定版 `0.1.5`。最新版本请以链接中的 npm 页面
 为准。
 
 #### npm 预发布版（DSH 预览阶段推荐）
@@ -141,7 +141,7 @@ npx @deepseek-ai/dsh@0.1.1-rc.2 plugin --profile web add github:yangbobo2021/rel
 SHA。例如：
 
 ```bash
-npx @deepseek-ai/dsh@0.1.1-rc.2 plugin --profile web add github:yangbobo2021/relay-dsh-plugin-codex#v0.1.4
+npx @deepseek-ai/dsh@0.1.1-rc.2 plugin --profile web add github:yangbobo2021/relay-dsh-plugin-codex#v0.1.5
 ```
 
 官方 DSH CLI 会在需要时初始化 `web` Profile，通过 `pnpm` 安装所选软件包，

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "relay-dsh-plugin-codex",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relay-dsh-plugin-codex",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@openai/codex": "0.149.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relay-dsh-plugin-codex",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Codex conversation backend for DeepSeek Harness, powered by the Codex App Server with approvals and DSH tool support.",
   "keywords": ["dsh-plugin", "deepseek-harness", "dsh"],
   "license": "MIT",


### PR DESCRIPTION
## Summary
- Publish the execution-presentation and history-compatibility fixes already merged in #28 as stable 0.1.5.
- Align package manifest, lockfile, and bilingual fixed-version installation examples.
- Keep next unchanged; the release workflow publishes stable versions to latest via npm OIDC.

## Verification
- npm run verify: 232 unit tests and 121 component tests passed; typecheck and production build passed.
- Rebuilding produced no changes to tracked lib artifacts.
- npm pack --dry-run inspected: 21 intended files; no local validation data or logs.
- release-metadata validates v0.1.5 -> latest.
- Official DSH b150a551b8d465e31e418e1b2eaf5e79bbb7d28e remains clean and unchanged.

## Release Gate
Merge only after CI passes. Then tag the merged main commit v0.1.5, wait for the release workflow, and independently verify the npm artifact and latest dist-tag. Existing Threads retain their context; first-yield command output requires a newly created Session as documented in #28.