### PR TITLE
test: verify DSH 0.1.2-alpha.3

### DIFF
--- a/scripts/link-dsh-development-peers.mjs
+++ b/scripts/link-dsh-development-peers.mjs
@@ -12,8 +12,9 @@ const candidates = process.env.DSH_ROOT ? [resolve(process.env.DSH_ROOT)] : [
 const dsh = candidates.find(path => existsSync(join(path, 'apps/cli/package.json')));
 if (!dsh) throw new Error('Set DSH_ROOT to a prepared official deepseek-harness checkout.');
 const version = JSON.parse(readFileSync(join(dsh, 'apps/cli/package.json'), 'utf8')).version;
-if (version !== '0.1.2-alpha.2') {
-  throw new Error(`Expected verified DSH 0.1.2-alpha.2, found ${version}. Select the matching official checkout.`);
+const verifiedVersions = new Set(['0.1.2-alpha.2', '0.1.2-alpha.3']);
+if (!verifiedVersions.has(version)) {
+  throw new Error(`Expected a verified DSH 0.1.2 prerelease, found ${version}. Select an audited official checkout.`);
 }
 const sourceRoot = join(dsh, 'node_modules/.pnpm/node_modules/@deepseek-ai');
 const targetRoot = join(root, 'node_modules/@deepseek-ai');

--- a/test/CodexProcessProjection.spec.tsx
+++ b/test/CodexProcessProjection.spec.tsx
@@ -455,6 +455,10 @@ function runtime(events: readonly SessionEventLike[] = [], hasMore = false, defi
   const assembler = new ConversationNodeAssembler(
     { entries: () => definitions, fallbackEntry: () => undefined }, { entries: () => [testView] },
   )
+  // alpha.3 materializes target views lazily after the first consumer
+  // subscribes; alpha.2 eagerly materializes every registered view.
+  ;(assembler as ConversationNodeAssembler & { activateTarget?: (target: string) => boolean })
+    .activateTarget?.('chat')
   assembler.replaceWindow(events.map(input), hasMore)
   assembler.flush()
   return assembler
@@ -865,7 +869,7 @@ describe('minimal legacy presentation gate', () => {
 })
 
 
-describe('DSH alpha.2 packed delta transport', () => {
+describe('DSH packed delta transport', () => {
   it.each(['text', 'reasoning'] as const)('preserves raw %s content, visible anchors, and logical sequences', kind => {
     const raw = [' ', 'hello', ' ', 'world'].map((value, offset) =>
       chunk(3 + offset, { type: kind === 'text' ? 'text-delta' : 'reasoning-delta', index: 0, text: value }))


### PR DESCRIPTION
DSH 0.1.2-alpha.3 is now the audited official development checkout. The existing link guard only admitted alpha.2, and the direct ConversationNodeAssembler fixture assumed that every registered target was materialized eagerly.

This change admits both audited 0.1.2 prereleases and activates the chat target when the official assembler exposes alpha.3's lazy target API. Runtime code is unchanged. Codex passes 250 Node tests, 140 component tests, typecheck, and build against the official alpha.3 checkout.
