### PR TITLE
Prepare next DSH compatibility preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > **Now supports DSH `0.1.2-rc.1` while retaining `0.1.2-alpha.3` compatibility.** Plugin `0.2.2` is verified on both releases. [Install it from npm](https://www.npmjs.com/package/relay-dsh-plugin-codex) · [Compatibility evidence](https://github.com/yangbobo2021/Relay/tree/codex/relay-foundation/dsh-lab/dsh-0.1.2-rc.1-20260903).
 
-> **Release channels:** `latest` → `0.2.2`; `next` → `0.2.1-rc.1`.
+> **Release channels:** `latest` → `0.2.2`; `next` → `0.2.3-rc.1`.
 
 ```bash
 npx @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile web add relay-dsh-plugin-codex@0.2.2
@@ -15,7 +15,7 @@ npx @deepseek-ai/dsh@0.1.2-rc.1 web
 [![GitHub stars](https://img.shields.io/github/stars/yangbobo2021/relay-dsh-plugin-codex?style=flat)](https://github.com/yangbobo2021/relay-dsh-plugin-codex/stargazers)
 [![MIT license](https://img.shields.io/github/license/yangbobo2021/relay-dsh-plugin-codex)](LICENSE)
 [![DSH compatibility](https://img.shields.io/badge/DSH-0.1.1--rc.2%20%7C%200.1.2--alpha.2%20%7C%200.1.2--alpha.3-2f7d68)](https://github.com/deepseek-ai/deepseek-harness)
-[![npm provenance](https://img.shields.io/badge/npm_provenance-verified-2f9e44)](https://www.npmjs.com/package/relay-dsh-plugin-codex/v/0.2.1)
+[![npm provenance](https://img.shields.io/badge/npm_provenance-verified-2f9e44)](https://www.npmjs.com/package/relay-dsh-plugin-codex/v/0.2.2)
 
 English | [中文](README.zh.md)
 
@@ -129,7 +129,7 @@ Use `@latest` to install the current stable release:
 npx @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile web add relay-dsh-plugin-codex@latest
 ```
 
-At the time of writing, `latest` resolves to stable version `0.2.1`. The linked
+At the time of writing, `latest` resolves to stable version `0.2.2`. The linked
 npm page is the source of truth for the current version.
 
 #### npm prerelease (recommended during DSH preview)
@@ -143,7 +143,7 @@ on a global `codex` executable:
 npx @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile web add relay-dsh-plugin-codex@next
 ```
 
-The `next` tag remains on `0.2.1-rc.1`; `latest` points to `0.2.1`.
+The `next` tag points to `0.2.3-rc.1`; `latest` points to `0.2.2`.
 Check the npm registry for the currently published dist-tag before installing.
 
 This prerelease preserves native service-tier and resumed-thread settings, stops
@@ -173,7 +173,7 @@ npx @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile web add github:yangbobo2021/rel
 full Commit SHA instead. For example:
 
 ```bash
-npx @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile web add github:yangbobo2021/relay-dsh-plugin-codex#v0.2.2
+npx @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile web add github:yangbobo2021/relay-dsh-plugin-codex#v0.2.3-rc.1
 ```
 
 The official DSH CLI initializes the `web` Profile if it does not exist, asks
@@ -409,7 +409,7 @@ Report bugs and feature requests in this repository's
 
 ### Published stable installation
 
-Stable `0.2.1` targets DSH `0.1.1-rc.2`, `0.1.2-alpha.2`, and `0.1.2-alpha.3`; install it from npm `latest` or Git tag `v0.2.1`.
+Stable `0.2.2` targets DSH `0.1.1-rc.2` and the `0.1.2` preview line through `0.1.2-rc.1`; install it from npm `latest` or Git tag `v0.2.2`.
 
 ```sh
 npx @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile web add relay-dsh-plugin-codex@next

--- a/README.zh.md
+++ b/README.zh.md
@@ -2,7 +2,7 @@
 
 > **现已支持 DSH `0.1.2-rc.1`，并保留对 `0.1.2-alpha.3` 的兼容。** 插件 `0.2.2` 已在两个版本上完成验证。[从 npm 安装](https://www.npmjs.com/package/relay-dsh-plugin-codex) · [兼容性证据](https://github.com/yangbobo2021/Relay/tree/codex/relay-foundation/dsh-lab/dsh-0.1.2-rc.1-20260903)。
 
-> **发布通道：** `latest` → `0.2.2`；`next` → `0.2.1-rc.1`。
+> **发布通道：** `latest` → `0.2.2`；`next` → `0.2.3-rc.1`。
 
 ```bash
 npx @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile web add relay-dsh-plugin-codex@0.2.2
@@ -15,7 +15,7 @@ npx @deepseek-ai/dsh@0.1.2-rc.1 web
 [![GitHub Stars](https://img.shields.io/github/stars/yangbobo2021/relay-dsh-plugin-codex?style=flat)](https://github.com/yangbobo2021/relay-dsh-plugin-codex/stargazers)
 [![MIT 许可证](https://img.shields.io/github/license/yangbobo2021/relay-dsh-plugin-codex)](LICENSE)
 [![DSH 兼容版本](https://img.shields.io/badge/DSH-0.1.1--rc.2%20%7C%200.1.2--alpha.2%20%7C%200.1.2--alpha.3-2f7d68)](https://github.com/deepseek-ai/deepseek-harness)
-[![npm 来源证明](https://img.shields.io/badge/npm_provenance-verified-2f9e44)](https://www.npmjs.com/package/relay-dsh-plugin-codex/v/0.2.1)
+[![npm 来源证明](https://img.shields.io/badge/npm_provenance-verified-2f9e44)](https://www.npmjs.com/package/relay-dsh-plugin-codex/v/0.2.2)
 
 [English](README.md) | 中文
 
@@ -123,7 +123,7 @@ codex login
 npx @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile web add relay-dsh-plugin-codex@latest
 ```
 
-本文更新时，`latest` 指向稳定版 `0.2.1`。最新版本请以链接中的 npm 页面
+本文更新时，`latest` 指向稳定版 `0.2.2`。最新版本请以链接中的 npm 页面
 为准。
 
 #### npm 预发布版（DSH 预览阶段推荐）
@@ -136,7 +136,7 @@ npx @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile web add relay-dsh-plugin-codex@
 npx @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile web add relay-dsh-plugin-codex@next
 ```
 
-`next` 标签继续指向 `0.2.1-rc.1`；`latest` 指向 `0.2.1`。
+`next` 标签指向 `0.2.3-rc.1`；`latest` 指向 `0.2.2`。
 安装前请以 npm 注册表中实际发布的 dist-tag 为准。
 
 本次预发布保留原生服务档位和恢复后的配置，修复取消轮次的迟到命令清理，
@@ -160,7 +160,7 @@ npx @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile web add github:yangbobo2021/rel
 SHA。例如：
 
 ```bash
-npx @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile web add github:yangbobo2021/relay-dsh-plugin-codex#v0.2.2
+npx @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile web add github:yangbobo2021/relay-dsh-plugin-codex#v0.2.3-rc.1
 ```
 
 官方 DSH CLI 会在需要时初始化 `web` Profile，通过 `pnpm` 安装所选软件包，
@@ -419,7 +419,7 @@ npm pack
 
 ### 已发布稳定版安装
 
-稳定版 `0.2.1` 面向 DSH `0.1.1-rc.2`、`0.1.2-alpha.2` 和 `0.1.2-alpha.3`；可通过 npm `latest` 或 Git Tag `v0.2.1` 安装。
+稳定版 `0.2.2` 面向 DSH `0.1.1-rc.2` 以及截至 `0.1.2-rc.1` 的 `0.1.2` 预览版本线；可通过 npm `latest` 或 Git Tag `v0.2.2` 安装。
 
 ```sh
 npx @deepseek-ai/dsh@0.1.2-rc.1 plugin --profile web add relay-dsh-plugin-codex@next

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "relay-dsh-plugin-codex",
-  "version": "0.2.2",
+  "version": "0.2.3-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "relay-dsh-plugin-codex",
-      "version": "0.2.2",
+      "version": "0.2.3-rc.1",
       "license": "MIT",
       "dependencies": {
         "@openai/codex": "0.149.0",
         "lucide-react": "^1.37.0",
-        "relay-dsh-plugin-session-import": "0.2.2"
+        "relay-dsh-plugin-session-import": "0.2.3-rc.1"
       },
       "devDependencies": {
         "@testing-library/dom": "^10.4.1",
@@ -22,7 +22,7 @@
         "lightningcss": "1.32.0",
         "react": "^18.2.0",
         "react-dom": "^18.3.1",
-        "relay-dsh-plugin-session-import": "github:yangbobo2021/relay-dsh-plugin-session-import#6d63ceb10b292303f96136d933f5042d2419feb2",
+        "relay-dsh-plugin-session-import": "github:yangbobo2021/relay-dsh-plugin-session-import#1b789b387e334f65ba364b1ed5fb91c861c5d045",
         "tsdown": "0.22.2",
         "typescript": "6.0.3",
         "vitest": "^4.1.8"
@@ -2080,9 +2080,9 @@
       "license": "MIT"
     },
     "node_modules/relay-dsh-plugin-session-import": {
-      "version": "0.2.2",
-      "resolved": "git+ssh://git@github.com/yangbobo2021/relay-dsh-plugin-session-import.git#6d63ceb10b292303f96136d933f5042d2419feb2",
-      "integrity": "sha512-IO9/QtTTYZeizqPBqeNzs1QaAKat7OPkf4tfnNWL8VaaLmpPbS8uYlGs3KZPNSt4icPQNnhIPc+V19X1USbA7g==",
+      "version": "0.2.3-rc.1",
+      "resolved": "git+ssh://git@github.com/yangbobo2021/relay-dsh-plugin-session-import.git#1b789b387e334f65ba364b1ed5fb91c861c5d045",
+      "integrity": "sha512-ENwyWvn3+XxIqdT5Wikj3VbOIIUhxYGYN4pnmD2dpZ8lj7c0PslXbYHfUNuruHtEJt4DilUUfyrIszZkHkIFlQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "relay-dsh-plugin-codex",
-  "version": "0.2.2",
+  "version": "0.2.3-rc.1",
   "description": "Codex conversation backend for DeepSeek Harness, powered by the Codex App Server with approvals and DSH tool support.",
   "keywords": [
     "dsh-plugin",
@@ -114,7 +114,7 @@
   "dependencies": {
     "@openai/codex": "0.149.0",
     "lucide-react": "^1.37.0",
-    "relay-dsh-plugin-session-import": "0.2.2"
+    "relay-dsh-plugin-session-import": "0.2.3-rc.1"
   },
   "devDependencies": {
     "@testing-library/dom": "^10.4.1",
@@ -128,6 +128,6 @@
     "tsdown": "0.22.2",
     "typescript": "6.0.3",
     "vitest": "^4.1.8",
-    "relay-dsh-plugin-session-import": "github:yangbobo2021/relay-dsh-plugin-session-import#6d63ceb10b292303f96136d933f5042d2419feb2"
+    "relay-dsh-plugin-session-import": "github:yangbobo2021/relay-dsh-plugin-session-import#1b789b387e334f65ba364b1ed5fb91c861c5d045"
   }
 }

--- a/test/readme.test.mjs
+++ b/test/readme.test.mjs
@@ -84,9 +84,9 @@ test('README preserves standalone scope and every supported installation source'
   assert.match(english, /independently installable/i)
   assert.match(english, /only Relay package dependency is\s+the provider-neutral session import hub/i)
   assert.match(english, /no runtime dependency on the Relay application, Relay\s+Events, or another feature plugin/i)
-  const stableVersion = manifest.version.split('-')[0]
+  const releaseVersion = manifest.version
   const versionTag = new RegExp(
-    `github:yangbobo2021/relay-dsh-plugin-codex#v${stableVersion.replaceAll('.', '\\.')}`,
+    `github:yangbobo2021/relay-dsh-plugin-codex#v${releaseVersion.replaceAll('.', '\\.')}`,
   )
   for (const readme of [english, chinese]) {
     assert.match(readme, /https:\/\/www\.npmjs\.com\/package\/relay-dsh-plugin-codex/)

--- a/test/session-import-composition.test.mjs
+++ b/test/session-import-composition.test.mjs
@@ -8,7 +8,7 @@ const lock = JSON.parse(await readFile(new URL('../package-lock.json', import.me
 test("Codex depends on and loads the neutral session import hub first", async () => {
   assert.equal(manifest.dependencies["relay-dsh-plugin-session-import"], manifest.version);
   assert.equal(lock.packages[''].dependencies['relay-dsh-plugin-session-import'], manifest.version)
-  assert.match(lock.packages['node_modules/relay-dsh-plugin-session-import'].resolved, /#6d63ceb10b292303f96136d933f5042d2419feb2$/)
+  assert.match(lock.packages['node_modules/relay-dsh-plugin-session-import'].resolved, /#1b789b387e334f65ba364b1ed5fb91c861c5d045$/)
   assert.ok(manifest.dsh.client.inject.includes("relay-dsh-plugin-session-import"));
 
   const patch = await readFile(new URL("../cordis.patch.yml", import.meta.url), "utf8");


### PR DESCRIPTION
Publish the already validated DSH 0.1.2-alpha.3 through 0.1.2-rc.1 compatibility code as the next patch preview. This changes only package and lockfile versions; the release tag will publish to npm `next` after CI passes.